### PR TITLE
use managed identity for blob storage access

### DIFF
--- a/src/log-ingestion/LogsIngestion.cs
+++ b/src/log-ingestion/LogsIngestion.cs
@@ -13,7 +13,7 @@ namespace Sample.Function
     public class LogsIngestion
     {
         [FunctionName("LogsIngestion")]
-        public async Task Run([BlobTrigger("airflow-logs/{name}.log", Connection = "airflowlogs_STORAGE")]Stream myBlob, string name, ILogger log)
+        public async Task Run([BlobTrigger("airflow-logs/{name}.log", Connection = "AirflowLogsStorage")]Stream myBlob, string name, ILogger log)
         {
             log.LogInformation($"C# Blob trigger function starting processing blob\n Name: {name} \n Size: {myBlob.Length} Bytes");
 


### PR DESCRIPTION
Use Managed Identity for Blob Storage access for:
- BlobTrigger (logs storage account)
- AzureWebJobsStorage (function app storage)
